### PR TITLE
Introduce Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - '3.6'
+
+install:
+  - python setup.py develop
+
+script:
+  - flake8
+  - pytest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Validate the consensus model of the FBA
 
+[![Build Status](https://travis-ci.org/bosnet/isaac-consensus-protocol.svg?branch=master)](https://travis-ci.org/bosnet/isaac-consensus-protocol)
 
 ## Notice
 

--- a/src/bos_consensus/network/default_http/http.py
+++ b/src/bos_consensus/network/default_http/http.py
@@ -285,6 +285,7 @@ class Transport(BaseTransport):
         if self.server.ping is not None:
             self.server.ping.event.clear()
 
+        self.server.shutdown()
         self.server.server_close()
 
         return


### PR DESCRIPTION
There were broken tests on the only Linux, see [CI build](https://travis-ci.org/outsideris/isaac-consensus-protocol/builds/361487402).

I fixed it in [the commit](https://github.com/bosnet/isaac-consensus-protocol/commit/d167daf3b333a08ff18aac6ff96e36461a962221). 
As [python document](https://docs.python.org/2/library/socketserver.html#SocketServer.BaseServer.shutdown), `shutdown()` is `tell the serve_forever() loop to stop and wait until it does.` and `shutdown()` is thread-safe as [stackoverflow](https://stackoverflow.com/questions/24226210/how-to-shut-down-a-python-tcpserver-or-httpserver-or-simplehttpserver).
I don't know python much, but the server should be stopped with `shutdown()` because of `http.py` run server with `serve_forever()`.

https://github.com/bosnet/isaac-consensus-protocol/blob/e04c540ad96946d6a9b1401ba0c82b77d340bcfe/src/bos_consensus/network/default_http/http.py#L273-L290

And I introduce Travis-CI to run test cases automatically. Someone who has authority for turning on Travis-CI for this repository must turn on it on Travis-CI before merging this PR. You can see the result of CI in [my forked repository](https://travis-ci.org/outsideris/isaac-consensus-protocol/builds/361551985).